### PR TITLE
Add peerDependencies to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "karma": "^0.13.9",
     "karma-coverage": "^0.5.2",
     "karma-mocha": "^0.2.0",
-    "karma-phantomjs-launcher": "^0.2.1"
+    "karma-phantomjs-launcher": "^0.2.1",
+    "mocha": "^2.3.3",
+    "phantomjs": "^1.9.18"
   },
   "author": "Muut, Inc. and other contributors",
   "license": "MIT",


### PR DESCRIPTION
From npm 3, peerDependencies are not auto-installed anymore, and when trying to
`npm install` this project with npm 3 it shouts out a `UNMET PEER DEPENDENCY`.
I just added the missing dependencies to `devDependencies`.
