### PR TITLE
Add option to avoid adding enumerable properties to object.

### DIFF
--- a/dist/observable.js
+++ b/dist/observable.js
@@ -1,4 +1,4 @@
-;(function(window, undefined) {var observable = function(el) {
+;(function(window, undefined) {var observable = function(el, options) {
 
   /**
    * Extend the original object or create a new empty one
@@ -8,11 +8,27 @@
   el = el || {}
 
   /**
+   * Initialize options if needed
+   * @type { Object }
+   */
+  options = options || {}
+
+  /**
    * Private variables and methods
    */
 
   var callbacks = {},
-    onEachEvent = function(e, fn) { e.replace(/\S+/g, fn) }
+    onEachEvent = function(e, fn) { e.replace(/\S+/g, fn) },
+    defineProperty = function (key, value) {
+      if (options.nonEnumerable) {
+        Object.defineProperty(el, key, {
+          value: value,
+          enumerable: false
+        })
+      } else {
+        el[key] = value
+      }
+    }
 
   /**
    * Listen to the given space separated list of `events` and execute the `callback` each time an event is triggered.
@@ -21,7 +37,7 @@
    * @returns { Object } el
    */
 
-  el.on = function(events, fn) {
+  defineProperty('on', function(events, fn) {
     if (typeof fn != 'function')  return el
 
     onEachEvent(events, function(name, pos) {
@@ -30,7 +46,7 @@
     })
 
     return el
-  }
+  })
 
   /**
    * Removes the given space separated list of `events` listeners
@@ -39,7 +55,7 @@
    * @returns { Object } el
    */
 
-  el.off = function(events, fn) {
+  defineProperty('off', function(events, fn) {
     if (events == '*') callbacks = {}
     else {
       onEachEvent(events, function(name) {
@@ -52,7 +68,7 @@
       })
     }
     return el
-  }
+  })
 
   /**
    * Listen to the given space separated list of `events` and execute the `callback` at most once
@@ -61,13 +77,13 @@
    * @returns { Object } el
    */
 
-  el.one = function(events, fn) {
+  defineProperty('one', function(events, fn) {
     function on() {
       el.off(events, on)
       fn.apply(el, arguments)
     }
     return el.on(events, on)
-  }
+  })
 
   /**
    * Execute all callback functions that listen to the given space separated list of `events`
@@ -75,7 +91,7 @@
    * @returns { Object } el
    */
 
-  el.trigger = function(events) {
+  defineProperty('trigger', function(events) {
     var args = [].slice.call(arguments, 1)
 
     onEachEvent(events, function(name) {
@@ -99,11 +115,12 @@
     })
 
     return el
-  }
+  })
 
   return el
 
-}  /* istanbul ignore next */
+}
+  /* istanbul ignore next */
   // support CommonJS, AMD & browser
   if (typeof exports === 'object')
     module.exports = observable

--- a/dist/riot.observable.js
+++ b/dist/riot.observable.js
@@ -1,4 +1,4 @@
-riot.observable = function(el) {
+riot.observable = function(el, options) {
 
   /**
    * Extend the original object or create a new empty one
@@ -8,11 +8,27 @@ riot.observable = function(el) {
   el = el || {}
 
   /**
+   * Initialize options if needed
+   * @type { Object }
+   */
+  options = options || {}
+
+  /**
    * Private variables and methods
    */
 
   var callbacks = {},
-    onEachEvent = function(e, fn) { e.replace(/\S+/g, fn) }
+    onEachEvent = function(e, fn) { e.replace(/\S+/g, fn) },
+    defineProperty = function (key, value) {
+      if (options.nonEnumerable) {
+        Object.defineProperty(el, key, {
+          value: value,
+          enumerable: false
+        })
+      } else {
+        el[key] = value
+      }
+    }
 
   /**
    * Listen to the given space separated list of `events` and execute the `callback` each time an event is triggered.
@@ -21,7 +37,7 @@ riot.observable = function(el) {
    * @returns { Object } el
    */
 
-  el.on = function(events, fn) {
+  defineProperty('on', function(events, fn) {
     if (typeof fn != 'function')  return el
 
     onEachEvent(events, function(name, pos) {
@@ -30,7 +46,7 @@ riot.observable = function(el) {
     })
 
     return el
-  }
+  })
 
   /**
    * Removes the given space separated list of `events` listeners
@@ -39,7 +55,7 @@ riot.observable = function(el) {
    * @returns { Object } el
    */
 
-  el.off = function(events, fn) {
+  defineProperty('off', function(events, fn) {
     if (events == '*') callbacks = {}
     else {
       onEachEvent(events, function(name) {
@@ -52,7 +68,7 @@ riot.observable = function(el) {
       })
     }
     return el
-  }
+  })
 
   /**
    * Listen to the given space separated list of `events` and execute the `callback` at most once
@@ -61,13 +77,13 @@ riot.observable = function(el) {
    * @returns { Object } el
    */
 
-  el.one = function(events, fn) {
+  defineProperty('one', function(events, fn) {
     function on() {
       el.off(events, on)
       fn.apply(el, arguments)
     }
     return el.on(events, on)
-  }
+  })
 
   /**
    * Execute all callback functions that listen to the given space separated list of `events`
@@ -75,7 +91,7 @@ riot.observable = function(el) {
    * @returns { Object } el
    */
 
-  el.trigger = function(events) {
+  defineProperty('trigger', function(events) {
     var args = [].slice.call(arguments, 1)
 
     onEachEvent(events, function(name) {
@@ -99,7 +115,7 @@ riot.observable = function(el) {
     })
 
     return el
-  }
+  })
 
   return el
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-var observable = function(el) {
+var observable = function(el, options) {
 
   /**
    * Extend the original object or create a new empty one
@@ -8,11 +8,27 @@ var observable = function(el) {
   el = el || {}
 
   /**
+   * Initialize options if needed
+   * @type { Object }
+   */
+  options = options || {}
+
+  /**
    * Private variables and methods
    */
 
   var callbacks = {},
-    onEachEvent = function(e, fn) { e.replace(/\S+/g, fn) }
+    onEachEvent = function(e, fn) { e.replace(/\S+/g, fn) },
+    defineProperty = function (key, value) {
+      if (options.nonEnumerable) {
+        Object.defineProperty(el, key, {
+          value: value,
+          enumerable: false
+        })
+      } else {
+        el[key] = value
+      }
+    }
 
   /**
    * Listen to the given space separated list of `events` and execute the `callback` each time an event is triggered.
@@ -21,7 +37,7 @@ var observable = function(el) {
    * @returns { Object } el
    */
 
-  el.on = function(events, fn) {
+  defineProperty('on', function(events, fn) {
     if (typeof fn != 'function')  return el
 
     onEachEvent(events, function(name, pos) {
@@ -30,7 +46,7 @@ var observable = function(el) {
     })
 
     return el
-  }
+  })
 
   /**
    * Removes the given space separated list of `events` listeners
@@ -39,7 +55,7 @@ var observable = function(el) {
    * @returns { Object } el
    */
 
-  el.off = function(events, fn) {
+  defineProperty('off', function(events, fn) {
     if (events == '*') callbacks = {}
     else {
       onEachEvent(events, function(name) {
@@ -52,7 +68,7 @@ var observable = function(el) {
       })
     }
     return el
-  }
+  })
 
   /**
    * Listen to the given space separated list of `events` and execute the `callback` at most once
@@ -61,13 +77,13 @@ var observable = function(el) {
    * @returns { Object } el
    */
 
-  el.one = function(events, fn) {
+  defineProperty('one', function(events, fn) {
     function on() {
       el.off(events, on)
       fn.apply(el, arguments)
     }
     return el.on(events, on)
-  }
+  })
 
   /**
    * Execute all callback functions that listen to the given space separated list of `events`
@@ -75,7 +91,7 @@ var observable = function(el) {
    * @returns { Object } el
    */
 
-  el.trigger = function(events) {
+  defineProperty('trigger', function(events) {
     var args = [].slice.call(arguments, 1)
 
     onEachEvent(events, function(name) {
@@ -99,7 +115,7 @@ var observable = function(el) {
     })
 
     return el
-  }
+  })
 
   return el
 

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -1,3 +1,15 @@
+/*
+ * Equivalent to Object.propertyIsEnumerable
+ */
+function hasEnumerableProperty(object, key) {
+  for (var k in object) {
+    if (key === k) {
+      return true
+    }
+  }
+  return false
+}
+
 describe('Core specs', function() {
   var el = observable(),
       counter = 0
@@ -8,6 +20,19 @@ describe('Core specs', function() {
 
   afterEach(function() {
     el.off('*')
+  })
+
+  it('set enumerable property by default', function () {
+
+    expect(hasEnumerableProperty(el, 'on')).to.be(true)
+
+  })
+
+  it('set non-enumerable property when option passed', function () {
+
+    el = observable(null, {nonEnumerable: true})
+    expect(hasEnumerableProperty(el, 'on')).to.be(false)
+
   })
 
   it('single listener', function() {


### PR DESCRIPTION
Hi,

I am using Riot in my project and I wanted to stick with this observable implementation
but I had some issues with the added properties being enumerable so I added
an option to allow to make these non-enumerable.

The option being disabled by default, this should not break any existing code.

I was not sure about `Object.propertyIsEnumerable` browser support so I added a simple
helper in the tests instead.

Cheers.
