### PR TITLE
fix an "off" method problem

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,10 @@ var observable = function(el) {
         if (fn) {
           var arr = callbacks[name]
           for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-            if (cb == fn) arr.splice(i--, 1)
+            if (cb === fn || cb.__ORI_CALLBACK__ === fn){
+				arr.splice(i--, 1);
+				delete cb.__ORI_CALLBACK__;
+			}
           }
         } else delete callbacks[name]
       })
@@ -71,6 +74,14 @@ var observable = function(el) {
       el.off(events, on)
       fn.apply(el, arguments)
     }
+	
+	Object.defineProperty(on, '__ORI_CALLBACK__', {
+		value: fn,
+		enumerable: false,
+		writable: false,
+		configurable: true
+	});
+	
     return el.on(events, on)
   })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,9 +52,9 @@ var observable = function(el) {
         if (fn) {
           var arr = callbacks[name]
           for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-            if (cb === fn || cb.__ORI_CALLBACK__ === fn){
-              arr.splice(i--, 1);
-              delete cb.__ORI_CALLBACK__;
+            if (cb === fn || cb.__ORI_CALLBACK__ === fn) {
+              arr.splice(i--, 1)
+              delete cb.__ORI_CALLBACK__
             }
           }
         } else delete callbacks[name]
@@ -74,14 +74,14 @@ var observable = function(el) {
       el.off(events, on)
       fn.apply(el, arguments)
     }
-  
+
     Object.defineProperty(on, '__ORI_CALLBACK__', {
       value: fn,
       enumerable: false,
       writable: false,
       configurable: true
-    });
-  
+    })
+
     return el.on(events, on)
   })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,9 +53,9 @@ var observable = function(el) {
           var arr = callbacks[name]
           for (var i = 0, cb; cb = arr && arr[i]; ++i) {
             if (cb === fn || cb.__ORI_CALLBACK__ === fn){
-				arr.splice(i--, 1);
-				delete cb.__ORI_CALLBACK__;
-			}
+              arr.splice(i--, 1);
+              delete cb.__ORI_CALLBACK__;
+            }
           }
         } else delete callbacks[name]
       })
@@ -74,14 +74,14 @@ var observable = function(el) {
       el.off(events, on)
       fn.apply(el, arguments)
     }
-	
-	Object.defineProperty(on, '__ORI_CALLBACK__', {
-		value: fn,
-		enumerable: false,
-		writable: false,
-		configurable: true
-	});
-	
+  
+    Object.defineProperty(on, '__ORI_CALLBACK__', {
+      value: fn,
+      enumerable: false,
+      writable: false,
+      configurable: true
+    });
+  
     return el.on(events, on)
   })
 


### PR DESCRIPTION
fixed that make it can use "off" method to remove event handle using "one" method bounded.

test code:

``` js
var fn = function(){alert('jack')};
var obj = observable();
obj.one('hi', fn);
obj.off('hi', fn);
obj.trigger('hi');
```
