### PR TITLE
Add event.namespace support

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -27,7 +27,6 @@ car.trigger('start')
 
 @returns the given object `el` or a new observable instance
 
-
 ### <a name="on"></a> el.on(events, callback)
 
 Listen to the given space separated list of `events` and execute the `callback` each time an event is triggered.
@@ -134,3 +133,25 @@ el.trigger('start', { fuel: 89 }, true)
 ```
 
 @returns `el`
+
+### <a name="namespacing"></a> namespacing
+
+Events can be namespaced on a single level by using a `.` delimiter. Namespaced events listen to the primary event and can also be specifically triggered or removed.
+
+``` js
+// listen to start and start.honda events
+el.on('start.honda', function() {
+})
+
+// trigger all start events (including start.honda)
+el.trigger('start')
+
+// trigger only start.honda events
+el.trigger('start.honda')
+
+// remove only honda start events
+el.off('start.honda')
+
+// remove all start events (including start.honda)
+el.off('start')
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,12 @@ var observable = function(el) {
    */
   var callbacks = {},
     slice = Array.prototype.slice,
-    onEachEvent = function(e, fn) { e.replace(/\S+/g, fn) }
+    onEachEvent = function(e, fn) { e.replace(/\S+/g, function(name, pos, ns) {
+      name = name.split('.')
+      ns   = name.splice(1).join('.')
+      name = name[0]
+      fn(name, pos, ns)
+    })}
 
   // extend the object adding the observable methods
   Object.defineProperties(el, {
@@ -26,9 +31,10 @@ var observable = function(el) {
       value: function(events, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos) {
+        onEachEvent(events, function(name, pos, ns) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
+          fn.ns = ns
         })
 
         return el
@@ -48,11 +54,11 @@ var observable = function(el) {
       value: function(events, fn) {
         if (events == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name) {
-            if (fn) {
+          onEachEvent(events, function(name, pos, ns) {
+            if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-                if (cb == fn) arr.splice(i--, 1)
+                if (cb == fn || ns && cb.ns == ns) arr.splice(i--, 1)
               }
             } else delete callbacks[name]
           })
@@ -100,14 +106,14 @@ var observable = function(el) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name) {
+        onEachEvent(events, function(name, pos, ns) {
 
           fns = slice.call(callbacks[name] || [], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) return
             fn.busy = 1
-            fn.apply(el, fn.typed ? [name].concat(args) : args)
+            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
             if (fns[i] !== fn) { i-- }
             fn.busy = 0
           }


### PR DESCRIPTION
One of the limitations of (riot) observable is the lack of name spacing. 

This is particularly apparent when attempting to bind multiple tags to a single datastore. For example: 

``` javascript
// <tag1>
this.on('mount',function(){
    usersStore.on('changed.tag1', function(items){ 
        this.update() 
    }) 
})
this.on('unmount',function(){
    usersStore.off('changed.tag1')
})

// <tag2>
this.on('mount',function(){
    usersStore.on('changed.tag2', function(items){ 
        this.update() 
    }) 
})
this.on('unmount',function(){
    usersStore.off('changed.tag2')
})
```

With the above example ideally we would want both tags to update when the store emits a "changed" event —currently it requires the store to emit both events: 'changed.tag1' and 'changed.tag2'.

With namespacing both tags will update when a 'changed' event is triggered. Equally important on unmount only the change event related to the tag in question will be removed. All 'changed' events can still be removed by calling .off('changed').

This minor change massively increases the power and flexibility of the emitter with minimal downside. Yes, it's possible that a few current users may see a change in behaviour if they use dots in their events, but I suspect this user count will be low as the dot is typically used to address namespacing (see jQuery as an example: https://api.jquery.com/event.namespace/ ).

This is one of the reasons why I don't use Riots observable. It would be great if it had this feature. 

Thanks.

Another example:

``` javascript
var test = {}
observable(test)

test.on('hello',function(a){console.log('hello',a)}) 
test.on('hello.world',function(a){console.log('hello,world',a)}) 

test.trigger('hello','both')
test.trigger('hello.world','one')
test.off('hello.world')
test.trigger('hello','just "hello" ')
```
