### PR TITLE
Faster onEachEvent event (including namespaces)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,10 +18,14 @@ var observable = function(el) {
    */
   var callbacks = {},
     slice = Array.prototype.slice,
-    onEachEvent = function(e, fn) { e.replace(EVENTS_GROUP_REGEX, function(name, pos, ns) {
-      name = name.split('.')
-      fn(name[0], pos, name.splice(1).join('.'))
-    })}
+    onEachEvent = function(e, fn) {
+      var es = e.split(' '), l = es.length, i = 0, name, indx
+      for (; i < l; i++) {
+        name = es[i]
+        indx = name.indexOf('.')
+        if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
+      }
+    }
 
   // extend the object adding the observable methods
   Object.defineProperties(el, {


### PR DESCRIPTION
Roughly 30% faster with simple events:

```
new-observable#simple event x 1,801,581 ops/sec ±1.03% (87 runs sampled)
new-observable#namespaced event x 1,697,375 ops/sec ±4.13% (85 runs sampled)
new-observable#multiple events x 259,675 ops/sec ±1.62% (82 runs sampled)

old-observable#simple event x 1,385,113 ops/sec ±1.00% (88 runs sampled)
old-observable#multiple events x 238,766 ops/sec ±3.05% (81 runs sampled)
```
