### PR TITLE
Feature/remove spaced events

### DIFF
--- a/dist/es6.observable.js
+++ b/dist/es6.observable.js
@@ -14,20 +14,6 @@ var observable = function(el) {
     slice = Array.prototype.slice
 
   /**
-   * Private Methods
-   */
-
-  /**
-   * Helper function needed to get and loop all the event in a string
-   * @param   { String }   name - event string
-   * @param   {Function}   fn - callback
-   */
-  function parseEvent(name, fn) {
-    var indx = name.indexOf('.')
-    if (name) fn(~indx ? name.substring(0, indx) : name, ~indx ? name.slice(indx + 1) : null)
-  }
-
-  /**
    * Public Api
    */
 
@@ -42,13 +28,8 @@ var observable = function(el) {
      */
     on: {
       value: function(event, fn) {
-        if (typeof fn != 'function')  return el
-
-        parseEvent(event, function(name, ns) {
-          (callbacks[name] = callbacks[name] || []).push(fn)
-          fn.ns = ns
-        })
-
+        if (typeof fn == 'function')
+          (callbacks[event] = callbacks[event] || []).push(fn)
         return el
       },
       enumerable: false,
@@ -66,14 +47,12 @@ var observable = function(el) {
       value: function(event, fn) {
         if (event == '*' && !fn) callbacks = {}
         else {
-          parseEvent(event, function(name, ns) {
-            if (fn || ns) {
-              var arr = callbacks[name]
-              for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-                if (cb == fn || ns && cb.ns == ns) arr.splice(i--, 1)
-              }
-            } else delete callbacks[name]
-          })
+          if (fn) {
+            var arr = callbacks[event]
+            for (var i = 0, cb; cb = arr && arr[i]; ++i) {
+              if (cb == fn) arr.splice(i--, 1)
+            }
+          } else delete callbacks[event]
         }
         return el
       },
@@ -114,25 +93,23 @@ var observable = function(el) {
         // getting the arguments
         var arglen = arguments.length - 1,
           args = new Array(arglen),
-          fns
+          fns,
+          fn,
+          i
 
-        for (var i = 0; i < arglen; i++) {
+        for (i = 0; i < arglen; i++) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        parseEvent(event, function(name, ns) {
+        fns = slice.call(callbacks[event] || [], 0)
 
-          fns = slice.call(callbacks[name] || [], 0)
+        for (i = 0; fn = fns[i]; ++i) {
+          fn.apply(el, args)
+          if (fns[i] !== fn) { i-- }
+        }
 
-          for (var i = 0, fn; fn = fns[i]; ++i) {
-            if (!ns || fn.ns == ns) fn.apply(el, args)
-            if (fns[i] !== fn) { i-- }
-          }
-
-          if (callbacks['*'] && name != '*')
-            el.trigger.apply(el, ['*', name].concat(args))
-
-        })
+        if (callbacks['*'] && event != '*')
+          el.trigger.apply(el, ['*', event].concat(args))
 
         return el
       },

--- a/dist/es6.observable.js
+++ b/dist/es6.observable.js
@@ -18,17 +18,13 @@ var observable = function(el) {
    */
 
   /**
-   * Helper function needed to get and loop all the events in a string
-   * @param   { String }   e - event string
+   * Helper function needed to get and loop all the event in a string
+   * @param   { String }   name - event string
    * @param   {Function}   fn - callback
    */
-  function onEachEvent(e, fn) {
-    var es = e.split(' '), l = es.length, i = 0, name, indx
-    for (; i < l; i++) {
-      name = es[i]
-      indx = name.indexOf('.')
-      if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
-    }
+  function parseEvent(name, fn) {
+    var indx = name.indexOf('.')
+    if (name) fn(~indx ? name.substring(0, indx) : name, ~indx ? name.slice(indx + 1) : null)
   }
 
   /**
@@ -38,19 +34,18 @@ var observable = function(el) {
   // extend the el object adding the observable methods
   Object.defineProperties(el, {
     /**
-     * Listen to the given space separated list of `events` and
+     * Listen to the given `event` ands
      * execute the `callback` each time an event is triggered.
-     * @param  { String } events - events ids
+     * @param  { String } event - event id
      * @param  { Function } fn - callback function
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(event, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos, ns) {
+        parseEvent(event, function(name, ns) {
           (callbacks[name] = callbacks[name] || []).push(fn)
-          fn.typed = pos > 0
           fn.ns = ns
         })
 
@@ -62,16 +57,16 @@ var observable = function(el) {
     },
 
     /**
-     * Removes the given space separated list of `events` listeners
-     * @param   { String } events - events ids
+     * Removes the given `event` listeners
+     * @param   { String } event - event id
      * @param   { Function } fn - callback function
      * @returns { Object } el
      */
     off: {
-      value: function(events, fn) {
-        if (events == '*' && !fn) callbacks = {}
+      value: function(event, fn) {
+        if (event == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name, pos, ns) {
+          parseEvent(event, function(name, ns) {
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
@@ -88,19 +83,19 @@ var observable = function(el) {
     },
 
     /**
-     * Listen to the given space separated list of `events` and
+     * Listen to the given `event` and
      * execute the `callback` at most once
-     * @param   { String } events - events ids
+     * @param   { String } event - event id
      * @param   { Function } fn - callback function
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(event, fn) {
         function on() {
-          el.off(events, on)
+          el.off(event, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(event, on)
       },
       enumerable: false,
       writable: false,
@@ -109,12 +104,12 @@ var observable = function(el) {
 
     /**
      * Execute all callback functions that listen to
-     * the given space separated list of `events`
-     * @param   { String } events - events ids
+     * the given `event`
+     * @param   { String } event - event id
      * @returns { Object } el
      */
     trigger: {
-      value: function(events) {
+      value: function(event) {
 
         // getting the arguments
         var arglen = arguments.length - 1,
@@ -125,12 +120,12 @@ var observable = function(el) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name, pos, ns) {
+        parseEvent(event, function(name, ns) {
 
           fns = slice.call(callbacks[name] || [], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
-            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
+            if (!ns || fn.ns == ns) fn.apply(el, args)
             if (fns[i] !== fn) { i-- }
           }
 

--- a/dist/observable.js
+++ b/dist/observable.js
@@ -18,17 +18,13 @@
    */
 
   /**
-   * Helper function needed to get and loop all the events in a string
-   * @param   { String }   e - event string
+   * Helper function needed to get and loop all the event in a string
+   * @param   { String }   name - event string
    * @param   {Function}   fn - callback
    */
-  function onEachEvent(e, fn) {
-    var es = e.split(' '), l = es.length, i = 0, name, indx
-    for (; i < l; i++) {
-      name = es[i]
-      indx = name.indexOf('.')
-      if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
-    }
+  function parseEvent(name, fn) {
+    var indx = name.indexOf('.')
+    if (name) fn(~indx ? name.substring(0, indx) : name, ~indx ? name.slice(indx + 1) : null)
   }
 
   /**
@@ -38,19 +34,18 @@
   // extend the el object adding the observable methods
   Object.defineProperties(el, {
     /**
-     * Listen to the given space separated list of `events` and
+     * Listen to the given `event` ands
      * execute the `callback` each time an event is triggered.
-     * @param  { String } events - events ids
+     * @param  { String } event - event id
      * @param  { Function } fn - callback function
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(event, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos, ns) {
+        parseEvent(event, function(name, ns) {
           (callbacks[name] = callbacks[name] || []).push(fn)
-          fn.typed = pos > 0
           fn.ns = ns
         })
 
@@ -62,16 +57,16 @@
     },
 
     /**
-     * Removes the given space separated list of `events` listeners
-     * @param   { String } events - events ids
+     * Removes the given `event` listeners
+     * @param   { String } event - event id
      * @param   { Function } fn - callback function
      * @returns { Object } el
      */
     off: {
-      value: function(events, fn) {
-        if (events == '*' && !fn) callbacks = {}
+      value: function(event, fn) {
+        if (event == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name, pos, ns) {
+          parseEvent(event, function(name, ns) {
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
@@ -88,19 +83,19 @@
     },
 
     /**
-     * Listen to the given space separated list of `events` and
+     * Listen to the given `event` and
      * execute the `callback` at most once
-     * @param   { String } events - events ids
+     * @param   { String } event - event id
      * @param   { Function } fn - callback function
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(event, fn) {
         function on() {
-          el.off(events, on)
+          el.off(event, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(event, on)
       },
       enumerable: false,
       writable: false,
@@ -109,12 +104,12 @@
 
     /**
      * Execute all callback functions that listen to
-     * the given space separated list of `events`
-     * @param   { String } events - events ids
+     * the given `event`
+     * @param   { String } event - event id
      * @returns { Object } el
      */
     trigger: {
-      value: function(events) {
+      value: function(event) {
 
         // getting the arguments
         var arglen = arguments.length - 1,
@@ -125,12 +120,12 @@
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name, pos, ns) {
+        parseEvent(event, function(name, ns) {
 
           fns = slice.call(callbacks[name] || [], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
-            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
+            if (!ns || fn.ns == ns) fn.apply(el, args)
             if (fns[i] !== fn) { i-- }
           }
 

--- a/dist/riot.observable.js
+++ b/dist/riot.observable.js
@@ -14,20 +14,6 @@ riot.observable = function(el) {
     slice = Array.prototype.slice
 
   /**
-   * Private Methods
-   */
-
-  /**
-   * Helper function needed to get and loop all the event in a string
-   * @param   { String }   name - event string
-   * @param   {Function}   fn - callback
-   */
-  function parseEvent(name, fn) {
-    var indx = name.indexOf('.')
-    if (name) fn(~indx ? name.substring(0, indx) : name, ~indx ? name.slice(indx + 1) : null)
-  }
-
-  /**
    * Public Api
    */
 
@@ -42,13 +28,8 @@ riot.observable = function(el) {
      */
     on: {
       value: function(event, fn) {
-        if (typeof fn != 'function')  return el
-
-        parseEvent(event, function(name, ns) {
-          (callbacks[name] = callbacks[name] || []).push(fn)
-          fn.ns = ns
-        })
-
+        if (typeof fn == 'function')
+          (callbacks[event] = callbacks[event] || []).push(fn)
         return el
       },
       enumerable: false,
@@ -66,14 +47,12 @@ riot.observable = function(el) {
       value: function(event, fn) {
         if (event == '*' && !fn) callbacks = {}
         else {
-          parseEvent(event, function(name, ns) {
-            if (fn || ns) {
-              var arr = callbacks[name]
-              for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-                if (cb == fn || ns && cb.ns == ns) arr.splice(i--, 1)
-              }
-            } else delete callbacks[name]
-          })
+          if (fn) {
+            var arr = callbacks[event]
+            for (var i = 0, cb; cb = arr && arr[i]; ++i) {
+              if (cb == fn) arr.splice(i--, 1)
+            }
+          } else delete callbacks[event]
         }
         return el
       },
@@ -114,25 +93,23 @@ riot.observable = function(el) {
         // getting the arguments
         var arglen = arguments.length - 1,
           args = new Array(arglen),
-          fns
+          fns,
+          fn,
+          i
 
-        for (var i = 0; i < arglen; i++) {
+        for (i = 0; i < arglen; i++) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        parseEvent(event, function(name, ns) {
+        fns = slice.call(callbacks[event] || [], 0)
 
-          fns = slice.call(callbacks[name] || [], 0)
+        for (i = 0; fn = fns[i]; ++i) {
+          fn.apply(el, args)
+          if (fns[i] !== fn) { i-- }
+        }
 
-          for (var i = 0, fn; fn = fns[i]; ++i) {
-            if (!ns || fn.ns == ns) fn.apply(el, args)
-            if (fns[i] !== fn) { i-- }
-          }
-
-          if (callbacks['*'] && name != '*')
-            el.trigger.apply(el, ['*', name].concat(args))
-
-        })
+        if (callbacks['*'] && event != '*')
+          el.trigger.apply(el, ['*', event].concat(args))
 
         return el
       },

--- a/dist/riot.observable.js
+++ b/dist/riot.observable.js
@@ -18,17 +18,13 @@ riot.observable = function(el) {
    */
 
   /**
-   * Helper function needed to get and loop all the events in a string
-   * @param   { String }   e - event string
+   * Helper function needed to get and loop all the event in a string
+   * @param   { String }   name - event string
    * @param   {Function}   fn - callback
    */
-  function onEachEvent(e, fn) {
-    var es = e.split(' '), l = es.length, i = 0, name, indx
-    for (; i < l; i++) {
-      name = es[i]
-      indx = name.indexOf('.')
-      if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
-    }
+  function parseEvent(name, fn) {
+    var indx = name.indexOf('.')
+    if (name) fn(~indx ? name.substring(0, indx) : name, ~indx ? name.slice(indx + 1) : null)
   }
 
   /**
@@ -38,19 +34,18 @@ riot.observable = function(el) {
   // extend the el object adding the observable methods
   Object.defineProperties(el, {
     /**
-     * Listen to the given space separated list of `events` and
+     * Listen to the given `event` ands
      * execute the `callback` each time an event is triggered.
-     * @param  { String } events - events ids
+     * @param  { String } event - event id
      * @param  { Function } fn - callback function
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(event, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos, ns) {
+        parseEvent(event, function(name, ns) {
           (callbacks[name] = callbacks[name] || []).push(fn)
-          fn.typed = pos > 0
           fn.ns = ns
         })
 
@@ -62,16 +57,16 @@ riot.observable = function(el) {
     },
 
     /**
-     * Removes the given space separated list of `events` listeners
-     * @param   { String } events - events ids
+     * Removes the given `event` listeners
+     * @param   { String } event - event id
      * @param   { Function } fn - callback function
      * @returns { Object } el
      */
     off: {
-      value: function(events, fn) {
-        if (events == '*' && !fn) callbacks = {}
+      value: function(event, fn) {
+        if (event == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name, pos, ns) {
+          parseEvent(event, function(name, ns) {
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
@@ -88,19 +83,19 @@ riot.observable = function(el) {
     },
 
     /**
-     * Listen to the given space separated list of `events` and
+     * Listen to the given `event` and
      * execute the `callback` at most once
-     * @param   { String } events - events ids
+     * @param   { String } event - event id
      * @param   { Function } fn - callback function
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(event, fn) {
         function on() {
-          el.off(events, on)
+          el.off(event, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(event, on)
       },
       enumerable: false,
       writable: false,
@@ -109,12 +104,12 @@ riot.observable = function(el) {
 
     /**
      * Execute all callback functions that listen to
-     * the given space separated list of `events`
-     * @param   { String } events - events ids
+     * the given `event`
+     * @param   { String } event - event id
      * @returns { Object } el
      */
     trigger: {
-      value: function(events) {
+      value: function(event) {
 
         // getting the arguments
         var arglen = arguments.length - 1,
@@ -125,12 +120,12 @@ riot.observable = function(el) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name, pos, ns) {
+        parseEvent(event, function(name, ns) {
 
           fns = slice.call(callbacks[name] || [], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
-            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
+            if (!ns || fn.ns == ns) fn.apply(el, args)
             if (fns[i] !== fn) { i-- }
           }
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -29,18 +29,11 @@ car.trigger('start')
 
 ### <a name="on"></a> el.on(events, callback)
 
-Listen to the given space separated list of `events` and execute the `callback` each time an event is triggered.
+Listen to the given `event` and execute the `callback` each time an event is triggered.
 
 ``` js
 // listen to single event
-el.on('start', function() {
-
-})
-
-// listen to multiple events, the event type is given as the argument
-el.on('start stop', function(type) {
-
-  // type is either 'start' or 'stop'
+el.on('start', function(args) {
 
 })
 
@@ -56,7 +49,7 @@ el.on('*', function(event, param1, param2) {
 
 ### <a name="one"></a> el.one(event, callback)
 
-Listen to the given space separated list of `events` and execute the `callback` at most once
+Listen to the given `event` and execute the `callback` at most once
 
 ``` js
 // run the function once, even if 'start' is triggered multiple times
@@ -69,27 +62,27 @@ el.one('start', function() {
 
 ### <a name="off"></a> el.off(events)
 
-Removes the given space separated list of `events` listeners.
+Removes the given `event` listeners.
 
 ``` js
-el.off('start stop')
+el.off('start')
 ```
 
 @returns `el`
 
 ### <a name="off-fn"></a> el.off(events, fn)
 
-Removes the given callback from the list of events
+Removes the given callback listening to the `event`
 
 ``` js
 function doIt() {
   console.log('starting or ending')
 }
 
-el.on('start middle end', doIt)
+el.on('start', doIt)
 
-// remove a specific listener from start and end events
-el.off('start end', doIt)
+// remove a specific listener
+el.off('start', doIt)
 ```
 
 @returns `el`
@@ -108,11 +101,11 @@ Removes the specific callback function called on all the events
 
 ### <a name="trigger"></a> el.trigger(events)
 
-Execute all callback functions that listen to the given space separated list of `events`.
+Execute all callback functions that listen to the given `event`.
 
 ``` js
 el.trigger('start')
-el.trigger('render update')
+el.trigger('render')
 ```
 
 @returns `el`

--- a/doc/README.md
+++ b/doc/README.md
@@ -126,25 +126,3 @@ el.trigger('start', { fuel: 89 }, true)
 ```
 
 @returns `el`
-
-### <a name="namespacing"></a> namespacing
-
-Events can be namespaced on a single level by using a `.` delimiter. Namespaced events listen to the primary event and can also be specifically triggered or removed.
-
-``` js
-// listen to start and start.honda events
-el.on('start.honda', function() {
-})
-
-// trigger all start events (including start.honda)
-el.trigger('start')
-
-// trigger only start.honda events
-el.trigger('start.honda')
-
-// remove only honda start events
-el.off('start.honda')
-
-// remove all start events (including start.honda)
-el.off('start')
-```

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,20 +14,6 @@ var observable = function(el) {
     slice = Array.prototype.slice
 
   /**
-   * Private Methods
-   */
-
-  /**
-   * Helper function needed to get and loop all the event in a string
-   * @param   { String }   name - event string
-   * @param   {Function}   fn - callback
-   */
-  function parseEvent(name, fn) {
-    var indx = name.indexOf('.')
-    if (name) fn(~indx ? name.substring(0, indx) : name, ~indx ? name.slice(indx + 1) : null)
-  }
-
-  /**
    * Public Api
    */
 
@@ -42,13 +28,8 @@ var observable = function(el) {
      */
     on: {
       value: function(event, fn) {
-        if (typeof fn != 'function')  return el
-
-        parseEvent(event, function(name, ns) {
-          (callbacks[name] = callbacks[name] || []).push(fn)
-          fn.ns = ns
-        })
-
+        if (typeof fn == 'function')
+          (callbacks[event] = callbacks[event] || []).push(fn)
         return el
       },
       enumerable: false,
@@ -66,14 +47,12 @@ var observable = function(el) {
       value: function(event, fn) {
         if (event == '*' && !fn) callbacks = {}
         else {
-          parseEvent(event, function(name, ns) {
-            if (fn || ns) {
-              var arr = callbacks[name]
-              for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-                if (cb == fn || ns && cb.ns == ns) arr.splice(i--, 1)
-              }
-            } else delete callbacks[name]
-          })
+          if (fn) {
+            var arr = callbacks[event]
+            for (var i = 0, cb; cb = arr && arr[i]; ++i) {
+              if (cb == fn) arr.splice(i--, 1)
+            }
+          } else delete callbacks[event]
         }
         return el
       },
@@ -114,25 +93,23 @@ var observable = function(el) {
         // getting the arguments
         var arglen = arguments.length - 1,
           args = new Array(arglen),
-          fns
+          fns,
+          fn,
+          i
 
-        for (var i = 0; i < arglen; i++) {
+        for (i = 0; i < arglen; i++) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        parseEvent(event, function(name, ns) {
+        fns = slice.call(callbacks[event] || [], 0)
 
-          fns = slice.call(callbacks[name] || [], 0)
+        for (i = 0; fn = fns[i]; ++i) {
+          fn.apply(el, args)
+          if (fns[i] !== fn) { i-- }
+        }
 
-          for (var i = 0, fn; fn = fns[i]; ++i) {
-            if (!ns || fn.ns == ns) fn.apply(el, args)
-            if (fns[i] !== fn) { i-- }
-          }
-
-          if (callbacks['*'] && name != '*')
-            el.trigger.apply(el, ['*', name].concat(args))
-
-        })
+        if (callbacks['*'] && event != '*')
+          el.trigger.apply(el, ['*', event].concat(args))
 
         return el
       },

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,17 +18,13 @@ var observable = function(el) {
    */
 
   /**
-   * Helper function needed to get and loop all the events in a string
-   * @param   { String }   e - event string
+   * Helper function needed to get and loop all the event in a string
+   * @param   { String }   name - event string
    * @param   {Function}   fn - callback
    */
-  function onEachEvent(e, fn) {
-    var es = e.split(' '), l = es.length, i = 0, name, indx
-    for (; i < l; i++) {
-      name = es[i]
-      indx = name.indexOf('.')
-      if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
-    }
+  function parseEvent(name, fn) {
+    var indx = name.indexOf('.')
+    if (name) fn(~indx ? name.substring(0, indx) : name, ~indx ? name.slice(indx + 1) : null)
   }
 
   /**
@@ -38,19 +34,18 @@ var observable = function(el) {
   // extend the el object adding the observable methods
   Object.defineProperties(el, {
     /**
-     * Listen to the given space separated list of `events` and
+     * Listen to the given `event` ands
      * execute the `callback` each time an event is triggered.
-     * @param  { String } events - events ids
+     * @param  { String } event - event id
      * @param  { Function } fn - callback function
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(event, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos, ns) {
+        parseEvent(event, function(name, ns) {
           (callbacks[name] = callbacks[name] || []).push(fn)
-          fn.typed = pos > 0
           fn.ns = ns
         })
 
@@ -62,16 +57,16 @@ var observable = function(el) {
     },
 
     /**
-     * Removes the given space separated list of `events` listeners
-     * @param   { String } events - events ids
+     * Removes the given `event` listeners
+     * @param   { String } event - event id
      * @param   { Function } fn - callback function
      * @returns { Object } el
      */
     off: {
-      value: function(events, fn) {
-        if (events == '*' && !fn) callbacks = {}
+      value: function(event, fn) {
+        if (event == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name, pos, ns) {
+          parseEvent(event, function(name, ns) {
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
@@ -88,19 +83,19 @@ var observable = function(el) {
     },
 
     /**
-     * Listen to the given space separated list of `events` and
+     * Listen to the given `event` and
      * execute the `callback` at most once
-     * @param   { String } events - events ids
+     * @param   { String } event - event id
      * @param   { Function } fn - callback function
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(event, fn) {
         function on() {
-          el.off(events, on)
+          el.off(event, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(event, on)
       },
       enumerable: false,
       writable: false,
@@ -109,12 +104,12 @@ var observable = function(el) {
 
     /**
      * Execute all callback functions that listen to
-     * the given space separated list of `events`
-     * @param   { String } events - events ids
+     * the given `event`
+     * @param   { String } event - event id
      * @returns { Object } el
      */
     trigger: {
-      value: function(events) {
+      value: function(event) {
 
         // getting the arguments
         var arglen = arguments.length - 1,
@@ -125,12 +120,12 @@ var observable = function(el) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name, pos, ns) {
+        parseEvent(event, function(name, ns) {
 
           fns = slice.call(callbacks[name] || [], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
-            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
+            if (!ns || fn.ns == ns) fn.apply(el, args)
             if (fns[i] !== fn) { i-- }
           }
 

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
     "events"
   ],
   "devDependencies": {
-    "benchmark": "^2.1.0",
-    "coveralls": "^2.11.9",
-    "eslint": "^2.8.0",
+    "benchmark": "^2.1.1",
+    "coveralls": "^2.11.11",
+    "eslint": "^3.1.1",
     "expect.js": "^0.3.1",
-    "karma": "^0.13.22",
-    "karma-coverage": "^0.5.5",
-    "karma-mocha": "^0.2.2",
-    "karma-phantomjs-launcher": "^1.0.0",
-    "mocha": "^2.4.5",
+    "karma": "^1.1.1",
+    "karma-coverage": "^1.1.1",
+    "karma-mocha": "^1.1.1",
+    "karma-phantomjs-launcher": "^1.0.1",
+    "mocha": "^2.5.3",
     "phantomjs-prebuilt": "^2.1.7"
   },
   "author": "Muut, Inc. and other contributors",

--- a/test/bench/speed.js
+++ b/test/bench/speed.js
@@ -54,6 +54,21 @@ suite
       oldEl.off('*')
     }
   })
+  .add('old-observable#multiple events', function() {
+    iterationsCounter++
+    oldEl.trigger('foo')
+  }, {
+    onStart() {
+      iterationsCounter = 0
+      eventsCounter = 0
+      var fn = () => eventsCounter++
+      oldEl.on('foo bar', fn)
+    },
+    onComplete() {
+      expect(eventsCounter).to.be(iterationsCounter)
+      oldEl.off('*')
+    }
+  })
 
   .on('cycle', function(event) {
     console.log(String(event.target))

--- a/test/bench/speed.js
+++ b/test/bench/speed.js
@@ -9,7 +9,7 @@ var Benchmark = require('benchmark'),
   eventsCounter = 0
 
 suite
-  .add('new-observable#simple event', function() {
+  .add('new-observable', function() {
     iterationsCounter++
     el.trigger('foo')
   }, {
@@ -24,22 +24,7 @@ suite
       el.off('*')
     }
   })
-  .add('new-observable#namespaced event', function() {
-    iterationsCounter++
-    el.trigger('foo')
-  }, {
-    onStart() {
-      iterationsCounter = 0
-      eventsCounter = 0
-      var fn = () => eventsCounter++
-      el.on('foo.bar', fn)
-    },
-    onComplete() {
-      expect(eventsCounter).to.be(iterationsCounter)
-      el.off('*')
-    }
-  })
-  .add('old-observable#simple event', function() {
+  .add('old-observable', function() {
     iterationsCounter++
     oldEl.trigger('foo')
   }, {
@@ -54,22 +39,6 @@ suite
       oldEl.off('*')
     }
   })
-  .add('old-observable#multiple events', function() {
-    iterationsCounter++
-    oldEl.trigger('foo')
-  }, {
-    onStart() {
-      iterationsCounter = 0
-      eventsCounter = 0
-      var fn = () => eventsCounter++
-      oldEl.on('foo bar', fn)
-    },
-    onComplete() {
-      expect(eventsCounter).to.be(iterationsCounter)
-      oldEl.off('*')
-    }
-  })
-
   .on('cycle', function(event) {
     console.log(String(event.target))
   })

--- a/test/bench/speed.js
+++ b/test/bench/speed.js
@@ -39,21 +39,6 @@ suite
       el.off('*')
     }
   })
-  .add('new-observable#multiple events', function() {
-    iterationsCounter++
-    el.trigger('foo')
-  }, {
-    onStart() {
-      iterationsCounter = 0
-      eventsCounter = 0
-      var fn = () => eventsCounter++
-      el.on('foo bar', fn)
-    },
-    onComplete() {
-      expect(eventsCounter).to.be(iterationsCounter)
-      el.off('*')
-    }
-  })
   .add('old-observable#simple event', function() {
     iterationsCounter++
     oldEl.trigger('foo')
@@ -63,21 +48,6 @@ suite
       eventsCounter = 0
       var fn = () => eventsCounter++
       oldEl.on('foo', fn)
-    },
-    onComplete() {
-      expect(eventsCounter).to.be(iterationsCounter)
-      oldEl.off('*')
-    }
-  })
-  .add('old-observable#multiple events', function() {
-    iterationsCounter++
-    oldEl.trigger('foo')
-  }, {
-    onStart() {
-      iterationsCounter = 0
-      eventsCounter = 0
-      var fn = () => eventsCounter++
-      oldEl.on('foo bar', fn)
     },
     onComplete() {
       expect(eventsCounter).to.be(iterationsCounter)

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -10,7 +10,6 @@ module.exports = function(config) {
       'karma-phantomjs-launcher'
     ],
     files: [
-      '../node_modules/mocha/mocha.js',
       '../node_modules/expect.js/index.js',
       '../dist/observable.js',
       'specs/core.specs.js'

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -336,20 +336,5 @@ describe('Core specs', function() {
     expect(counter).to.be(2)
   })
 
-  it('The namespaced events are properly called', function() {
-
-    el
-      .on('hello', function(a) { counter++ })
-      .on('hello.world', function(a) { counter++ })
-
-    el.trigger('hello', 'both')
-    expect(counter).to.be(2)
-    el.trigger('hello.world', 'one')
-    expect(counter).to.be(3)
-    el.off('hello.world')
-    el.trigger('hello', 'just "hello"')
-    expect(counter).to.be(4)
-  })
-
 })
 

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -67,17 +67,21 @@ describe('Core specs', function() {
 
   })
 
-  it('multiple listeners with special chars', function() {
+  it('listeners with special chars', function() {
 
-    el.on('b/4 c-d d:x', function(e) {
-      if (++counter == 3) expect(e).to.be('d:x')
-    })
+    var handler = function() {
+      counter++
+    }
+
+    el.on('b/4', handler).on('c-d', handler).on('d:x', handler)
 
     el.one('d:x', function(arg) {
       expect(arg).to.be(true)
     })
 
     el.trigger('b/4').trigger('c-d').trigger('d:x', true)
+
+    expect(counter).to.be(3)
 
   })
 
@@ -130,18 +134,6 @@ describe('Core specs', function() {
     }
 
     el.on('r', r).on('s', r).off('s', r).trigger('r').trigger('s')
-
-  })
-
-  it('Remove multiple listeners', function() {
-
-    function fn() {
-      counter++
-    }
-
-    el.on('a1 b1', fn).on('c1', fn).off('a1 b1').off('c1').trigger('a1').trigger('b1').trigger('c1')
-
-    expect(counter).to.be(0)
 
   })
 
@@ -299,18 +291,6 @@ describe('Core specs', function() {
     expect(counter).to.be(0)
   })
 
-  it('multi trigger', function() {
-    var fn = function(val) {
-      counter ++
-      expect(val).to.be(true)
-    }
-
-    el.on('foo', fn).on('bar', fn)
-    el.trigger('foo bar', true)
-
-    expect(counter).to.be(2)
-  })
-
   it('remove handler while triggering', function() {
 
     function handler() {
@@ -335,7 +315,6 @@ describe('Core specs', function() {
 
   it('Do not block callback throwing errors', function() {
 
-    el.on('error', function() { counter++ })
     el.on('event', function() { counter++; throw 'OH NOES!' })
     el.on('event', function() { counter++ })
 


### PR DESCRIPTION
This patch makes riot-observable ~22% faster and a lot simpler but it removes the spaced events support
I think it's totally worth if we want make riot@3.0.0 faster
Patched observable

```
new-observable#simple event x 2,847,010 ops/sec ±1.12% (91 runs sampled)
new-observable#namespaced event x 2,891,754 ops/sec ±1.09% (91 runs sampled)
```

Current observable

```
new-observable#simple event x 2,233,131 ops/sec ±1.65% (90 runs sampled)
new-observable#namespaced event x 2,336,702 ops/sec ±0.87% (93 runs sampled)
```

Please let me know what you think
@tipiirai @rsbondi @aMarCruz @cognitom @rogueg 
