### PR TITLE
Add 'persist' parameter to execute events added after the event has b…

### DIFF
--- a/dist/es6.observable.js
+++ b/dist/es6.observable.js
@@ -41,15 +41,19 @@ var observable = function(el) {
      * execute the `callback` each time an event is triggered.
      * @param  { String } events - events ids
      * @param  { Function } fn - callback function
+     * @param  { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         if (typeof fn != 'function')  return el
 
         onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
+          callbacks[name].called = callbacks[name].called || false
+          if (callbacks[name].called && persist) fn.apply(el, fn.typed ? [name].concat(callbacks[name].called) : callbacks[name].called)
         })
 
         return el
@@ -90,15 +94,17 @@ var observable = function(el) {
      * execute the `callback` at most once
      * @param   { String } events - events ids
      * @param   { Function } fn - callback function
+     * @param   { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         function on() {
           el.off(events, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(events, on, persist)
       },
       enumerable: false,
       writable: false,
@@ -124,8 +130,12 @@ var observable = function(el) {
         }
 
         onEachEvent(events, function(name, pos) {
+          callbacks[name] = callbacks[name] || []
 
-          fns = slice.call(callbacks[name] || [], 0)
+          // Overwrite so only the last triggered value remains
+          callbacks[name].called = args
+
+          fns = slice.call(callbacks[name], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue

--- a/dist/observable.js
+++ b/dist/observable.js
@@ -41,15 +41,19 @@
      * execute the `callback` each time an event is triggered.
      * @param  { String } events - events ids
      * @param  { Function } fn - callback function
+     * @param  { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         if (typeof fn != 'function')  return el
 
         onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
+          callbacks[name].called = callbacks[name].called || false
+          if (callbacks[name].called && persist) fn.apply(el, fn.typed ? [name].concat(callbacks[name].called) : callbacks[name].called)
         })
 
         return el
@@ -90,15 +94,17 @@
      * execute the `callback` at most once
      * @param   { String } events - events ids
      * @param   { Function } fn - callback function
+     * @param   { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         function on() {
           el.off(events, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(events, on, persist)
       },
       enumerable: false,
       writable: false,
@@ -124,8 +130,12 @@
         }
 
         onEachEvent(events, function(name, pos) {
+          callbacks[name] = callbacks[name] || []
 
-          fns = slice.call(callbacks[name] || [], 0)
+          // Overwrite so only the last triggered value remains
+          callbacks[name].called = args
+
+          fns = slice.call(callbacks[name], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue

--- a/doc/README.md
+++ b/doc/README.md
@@ -27,9 +27,12 @@ car.trigger('start')
 
 @returns the given object `el` or a new observable instance
 
-### <a name="on"></a> el.on(events, callback)
+### <a name="on"></a> el.on(events, callback, persist)
 
 Listen to the given space separated list of `events` and execute the `callback` each time an event is triggered.
+
+If `persist` is set to `true`, then it will immediately execute `callback` *if* trigger has been
+called for the `event`. Useful for eliminating race-conditions with server data.
 
 ``` js
 // listen to single event
@@ -50,13 +53,21 @@ el.on('*', function(event, param1, param2) {
   // do something with the parameters
 })
 
+// delayed event registration
+el.trigger('start')
+el.on('start', function() {
+  // This will execute even though it is setup after the trigger
+}, true)
+
 ```
 
 @returns `el`
 
-### <a name="one"></a> el.one(event, callback)
+### <a name="one"></a> el.one(event, callback, persist)
 
 Listen to the given space separated list of `events` and execute the `callback` at most once
+
+Persist works the same as `on` event.
 
 ``` js
 // run the function once, even if 'start' is triggered multiple times

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,15 +41,19 @@ var observable = function(el) {
      * execute the `callback` each time an event is triggered.
      * @param  { String } events - events ids
      * @param  { Function } fn - callback function
+     * @param  { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         if (typeof fn != 'function')  return el
 
         onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
+          callbacks[name].called = callbacks[name].called || false
+          if (callbacks[name].called && persist) fn.apply(el, fn.typed ? [name].concat(callbacks[name].called) : callbacks[name].called)
         })
 
         return el
@@ -90,15 +94,17 @@ var observable = function(el) {
      * execute the `callback` at most once
      * @param   { String } events - events ids
      * @param   { Function } fn - callback function
+     * @param   { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         function on() {
           el.off(events, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(events, on, persist)
       },
       enumerable: false,
       writable: false,
@@ -124,8 +130,12 @@ var observable = function(el) {
         }
 
         onEachEvent(events, function(name, pos) {
+          callbacks[name] = callbacks[name] || []
 
-          fns = slice.call(callbacks[name] || [], 0)
+          // Overwrite so only the last triggered value remains
+          callbacks[name].called = args
+
+          fns = slice.call(callbacks[name], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -67,8 +67,39 @@ describe('Core specs', function() {
 
   })
 
-  it('multiple listeners with special chars', function() {
+  it('single listener with always', function(done) {
 
+    el.on('a', function(arg){
+      expect(arg).to.be(true)
+    })
+
+    el.trigger('a', true)
+
+    el.on('a', function(arg) {
+      expect(arg).to.be(true)
+      done()
+    }, true)
+
+  })
+
+  it('single listener without always', function(done) {
+
+    el.on('b', function(arg){
+      expect(arg).to.be(true)
+    })
+
+    el.trigger('b', true)
+
+    el.on('b', function(arg) {
+      done('This should not run')
+    })
+
+    setTimeout(done, 1000)
+
+  })
+
+  it('multiple listeners with special chars', function() {
+    var counter = 0
     el.on('b/4 c-d d:x', function(e) {
       if (++counter == 3) expect(e).to.be('d:x')
     })
@@ -82,12 +113,22 @@ describe('Core specs', function() {
   })
 
   it('one', function() {
-
+    var counter = 0
     el.one('g', function() {
       expect(++counter).to.be(1)
     })
 
     el.trigger('g').trigger('g')
+
+  })
+
+  it('one with always', function(done) {
+
+    el.trigger('g').trigger('g')
+    el.one('g', function() {
+      expect(++counter).to.be(1)
+      done()
+    }, true)
 
   })
 
@@ -400,4 +441,3 @@ describe('Core specs', function() {
     expect(counter).to.be(2)
   })
 })
-


### PR DESCRIPTION
…een triggered

Replacement for https://github.com/riot/observable/pull/20

This does not use namespaces.

The purpose of this is to capture events that should be triggered in highly dynamic environments and execute them. This prevents race conditions.

This is helpful in many situations, but a couple I've used it in are:
- my page is setup and waiting for websocket data from the server. Once a connection is made, trigger a connect event. There are times, when the websocket will connect before the page finishes loading. I still want the connect events to execute and ALWAYS execute everytime the connect event happens.
- mounting tags asynchronously from the server and one tag triggers an event that another tag needs to execute. With the persist, I don't have to worry about what order my tags are loaded in.

Basically, this solves any issue where race conditions are an issue with your events.

Example:

```
var app = {};
riot.observable(app);
app.trigger('connect');
app.on('connect', function(){
  // this will still execute even though it is setup AFTER the trigger
}, true); // <- note the persist boolean.
```
