### PR TITLE
Feature/persist Add 'persist' parameter to execute events added after the event has been triggered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-   - "0.12.0"
+   - "6.*"
 
 branches:
   only:

--- a/dist/es6.observable.js
+++ b/dist/es6.observable.js
@@ -41,15 +41,19 @@ var observable = function(el) {
      * execute the `callback` each time an event is triggered.
      * @param  { String } events - events ids
      * @param  { Function } fn - callback function
+     * @param  { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         if (typeof fn != 'function')  return el
 
         onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
+          callbacks[name].called = callbacks[name].called || false
+          if (callbacks[name].called && persist) fn.apply(el, fn.typed ? [name].concat(callbacks[name].called) : callbacks[name].called)
         })
 
         return el
@@ -90,15 +94,17 @@ var observable = function(el) {
      * execute the `callback` at most once
      * @param   { String } events - events ids
      * @param   { Function } fn - callback function
+     * @param   { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         function on() {
           el.off(events, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(events, on, persist)
       },
       enumerable: false,
       writable: false,
@@ -124,8 +130,12 @@ var observable = function(el) {
         }
 
         onEachEvent(events, function(name, pos) {
+          callbacks[name] = callbacks[name] || []
 
-          fns = slice.call(callbacks[name] || [], 0)
+          // Overwrite so only the last triggered value remains
+          callbacks[name].called = args
+
+          fns = slice.call(callbacks[name], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue

--- a/dist/es6.observable.js
+++ b/dist/es6.observable.js
@@ -25,7 +25,7 @@ var observable = function(el) {
   function onEachEvent(e, fn) {
     var es = e.split(' '), l = es.length, i = 0
     for (; i < l; i++) {
-      name = es[i]
+      var name = es[i]
       if (name) fn(name, i)
     }
   }
@@ -69,8 +69,8 @@ var observable = function(el) {
       value: function(events, fn) {
         if (events == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name, pos, ns) {
-            if (fn || ns) {
+          onEachEvent(events, function(name, pos) {
+            if (fn) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
                 if (cb == fn) arr.splice(i--, 1)
@@ -123,7 +123,7 @@ var observable = function(el) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name, pos, ns) {
+        onEachEvent(events, function(name, pos) {
 
           fns = slice.call(callbacks[name] || [], 0)
 

--- a/dist/es6.observable.js
+++ b/dist/es6.observable.js
@@ -23,11 +23,10 @@ var observable = function(el) {
    * @param   {Function}   fn - callback
    */
   function onEachEvent(e, fn) {
-    var es = e.split(' '), l = es.length, i = 0, name, indx
+    var es = e.split(' '), l = es.length, i = 0
     for (; i < l; i++) {
       name = es[i]
-      indx = name.indexOf('.')
-      if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
+      if (name) fn(name, i)
     }
   }
 
@@ -48,10 +47,9 @@ var observable = function(el) {
       value: function(events, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos, ns) {
+        onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
-          fn.ns = ns
         })
 
         return el
@@ -75,7 +73,7 @@ var observable = function(el) {
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-                if (cb == fn || ns && cb.ns == ns) arr.splice(i--, 1)
+                if (cb == fn) arr.splice(i--, 1)
               }
             } else delete callbacks[name]
           })
@@ -132,7 +130,7 @@ var observable = function(el) {
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue
             fn.busy = 1
-            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
+            fn.apply(el, fn.typed ? [name].concat(args) : args)
             if (fns[i] !== fn) { i-- }
             fn.busy = 0
           }

--- a/dist/observable.js
+++ b/dist/observable.js
@@ -25,7 +25,7 @@
   function onEachEvent(e, fn) {
     var es = e.split(' '), l = es.length, i = 0
     for (; i < l; i++) {
-      name = es[i]
+      var name = es[i]
       if (name) fn(name, i)
     }
   }
@@ -69,8 +69,8 @@
       value: function(events, fn) {
         if (events == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name, pos, ns) {
-            if (fn || ns) {
+          onEachEvent(events, function(name, pos) {
+            if (fn) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
                 if (cb == fn) arr.splice(i--, 1)
@@ -123,7 +123,7 @@
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name, pos, ns) {
+        onEachEvent(events, function(name, pos) {
 
           fns = slice.call(callbacks[name] || [], 0)
 

--- a/dist/observable.js
+++ b/dist/observable.js
@@ -41,15 +41,19 @@
      * execute the `callback` each time an event is triggered.
      * @param  { String } events - events ids
      * @param  { Function } fn - callback function
+     * @param  { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         if (typeof fn != 'function')  return el
 
         onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
+          callbacks[name].called = callbacks[name].called || false
+          if (callbacks[name].called && persist) fn.apply(el, fn.typed ? [name].concat(callbacks[name].called) : callbacks[name].called)
         })
 
         return el
@@ -90,15 +94,17 @@
      * execute the `callback` at most once
      * @param   { String } events - events ids
      * @param   { Function } fn - callback function
+     * @param   { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         function on() {
           el.off(events, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(events, on, persist)
       },
       enumerable: false,
       writable: false,
@@ -124,8 +130,12 @@
         }
 
         onEachEvent(events, function(name, pos) {
+          callbacks[name] = callbacks[name] || []
 
-          fns = slice.call(callbacks[name] || [], 0)
+          // Overwrite so only the last triggered value remains
+          callbacks[name].called = args
+
+          fns = slice.call(callbacks[name], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue

--- a/dist/observable.js
+++ b/dist/observable.js
@@ -23,11 +23,10 @@
    * @param   {Function}   fn - callback
    */
   function onEachEvent(e, fn) {
-    var es = e.split(' '), l = es.length, i = 0, name, indx
+    var es = e.split(' '), l = es.length, i = 0
     for (; i < l; i++) {
       name = es[i]
-      indx = name.indexOf('.')
-      if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
+      if (name) fn(name, i)
     }
   }
 
@@ -48,10 +47,9 @@
       value: function(events, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos, ns) {
+        onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
-          fn.ns = ns
         })
 
         return el
@@ -75,7 +73,7 @@
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-                if (cb == fn || ns && cb.ns == ns) arr.splice(i--, 1)
+                if (cb == fn) arr.splice(i--, 1)
               }
             } else delete callbacks[name]
           })
@@ -132,7 +130,7 @@
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue
             fn.busy = 1
-            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
+            fn.apply(el, fn.typed ? [name].concat(args) : args)
             if (fns[i] !== fn) { i-- }
             fn.busy = 0
           }

--- a/dist/riot.observable.js
+++ b/dist/riot.observable.js
@@ -25,7 +25,7 @@ riot.observable = function(el) {
   function onEachEvent(e, fn) {
     var es = e.split(' '), l = es.length, i = 0
     for (; i < l; i++) {
-      name = es[i]
+      var name = es[i]
       if (name) fn(name, i)
     }
   }
@@ -69,8 +69,8 @@ riot.observable = function(el) {
       value: function(events, fn) {
         if (events == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name, pos, ns) {
-            if (fn || ns) {
+          onEachEvent(events, function(name, pos) {
+            if (fn) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
                 if (cb == fn) arr.splice(i--, 1)
@@ -123,7 +123,7 @@ riot.observable = function(el) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name, pos, ns) {
+        onEachEvent(events, function(name, pos) {
 
           fns = slice.call(callbacks[name] || [], 0)
 

--- a/dist/riot.observable.js
+++ b/dist/riot.observable.js
@@ -23,11 +23,10 @@ riot.observable = function(el) {
    * @param   {Function}   fn - callback
    */
   function onEachEvent(e, fn) {
-    var es = e.split(' '), l = es.length, i = 0, name, indx
+    var es = e.split(' '), l = es.length, i = 0
     for (; i < l; i++) {
       name = es[i]
-      indx = name.indexOf('.')
-      if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
+      if (name) fn(name, i)
     }
   }
 
@@ -48,10 +47,9 @@ riot.observable = function(el) {
       value: function(events, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos, ns) {
+        onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
-          fn.ns = ns
         })
 
         return el
@@ -75,7 +73,7 @@ riot.observable = function(el) {
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-                if (cb == fn || ns && cb.ns == ns) arr.splice(i--, 1)
+                if (cb == fn) arr.splice(i--, 1)
               }
             } else delete callbacks[name]
           })
@@ -132,7 +130,7 @@ riot.observable = function(el) {
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue
             fn.busy = 1
-            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
+            fn.apply(el, fn.typed ? [name].concat(args) : args)
             if (fns[i] !== fn) { i-- }
             fn.busy = 0
           }

--- a/doc/README.md
+++ b/doc/README.md
@@ -27,9 +27,12 @@ car.trigger('start')
 
 @returns the given object `el` or a new observable instance
 
-### <a name="on"></a> el.on(events, callback)
+### <a name="on"></a> el.on(events, callback, persist)
 
 Listen to the given space separated list of `events` and execute the `callback` each time an event is triggered.
+
+If `persist` is set to `true`, then it will immediately execute `callback` *if* trigger has been
+called for the `event`. Useful for eliminating race-conditions with server data.
 
 ``` js
 // listen to single event
@@ -50,13 +53,21 @@ el.on('*', function(event, param1, param2) {
   // do something with the parameters
 })
 
+// delayed event registration
+el.trigger('start')
+el.on('start', function() {
+  // This will execute even though it is setup after the trigger
+}, true)
+
 ```
 
 @returns `el`
 
-### <a name="one"></a> el.one(event, callback)
+### <a name="one"></a> el.one(event, callback, persist)
 
 Listen to the given space separated list of `events` and execute the `callback` at most once
+
+Persist works the same as `on` event.
 
 ``` js
 // run the function once, even if 'start' is triggered multiple times

--- a/doc/README.md
+++ b/doc/README.md
@@ -133,25 +133,3 @@ el.trigger('start', { fuel: 89 }, true)
 ```
 
 @returns `el`
-
-### <a name="namespacing"></a> namespacing
-
-Events can be namespaced on a single level by using a `.` delimiter. Namespaced events listen to the primary event and can also be specifically triggered or removed.
-
-``` js
-// listen to start and start.honda events
-el.on('start.honda', function() {
-})
-
-// trigger all start events (including start.honda)
-el.trigger('start')
-
-// trigger only start.honda events
-el.trigger('start.honda')
-
-// remove only honda start events
-el.off('start.honda')
-
-// remove all start events (including start.honda)
-el.off('start')
-```

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,15 +41,19 @@ var observable = function(el) {
      * execute the `callback` each time an event is triggered.
      * @param  { String } events - events ids
      * @param  { Function } fn - callback function
+     * @param  { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     on: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         if (typeof fn != 'function')  return el
 
         onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
+          callbacks[name].called = callbacks[name].called || false
+          if (callbacks[name].called && persist) fn.apply(el, fn.typed ? [name].concat(callbacks[name].called) : callbacks[name].called)
         })
 
         return el
@@ -90,15 +94,17 @@ var observable = function(el) {
      * execute the `callback` at most once
      * @param   { String } events - events ids
      * @param   { Function } fn - callback function
+     * @param   { Boolean } persist - should the callback be called immediately
+    *                      if the event has been called in the past?
      * @returns { Object } el
      */
     one: {
-      value: function(events, fn) {
+      value: function(events, fn, persist) {
         function on() {
           el.off(events, on)
           fn.apply(el, arguments)
         }
-        return el.on(events, on)
+        return el.on(events, on, persist)
       },
       enumerable: false,
       writable: false,
@@ -124,8 +130,12 @@ var observable = function(el) {
         }
 
         onEachEvent(events, function(name, pos) {
+          callbacks[name] = callbacks[name] || []
 
-          fns = slice.call(callbacks[name] || [], 0)
+          // Overwrite so only the last triggered value remains
+          callbacks[name].called = args
+
+          fns = slice.call(callbacks[name], 0)
 
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,11 +23,10 @@ var observable = function(el) {
    * @param   {Function}   fn - callback
    */
   function onEachEvent(e, fn) {
-    var es = e.split(' '), l = es.length, i = 0, name, indx
+    var es = e.split(' '), l = es.length, i = 0
     for (; i < l; i++) {
-      name = es[i]
-      indx = name.indexOf('.')
-      if (name) fn( ~indx ? name.substring(0, indx) : name, i, ~indx ? name.slice(indx + 1) : null)
+      var name = es[i]
+      if (name) fn(name, i)
     }
   }
 
@@ -48,10 +47,9 @@ var observable = function(el) {
       value: function(events, fn) {
         if (typeof fn != 'function')  return el
 
-        onEachEvent(events, function(name, pos, ns) {
+        onEachEvent(events, function(name, pos) {
           (callbacks[name] = callbacks[name] || []).push(fn)
           fn.typed = pos > 0
-          fn.ns = ns
         })
 
         return el
@@ -75,7 +73,7 @@ var observable = function(el) {
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
-                if (cb == fn || ns && cb.ns == ns) arr.splice(i--, 1)
+                if (cb == fn) arr.splice(i--, 1)
               }
             } else delete callbacks[name]
           })
@@ -132,7 +130,7 @@ var observable = function(el) {
           for (var i = 0, fn; fn = fns[i]; ++i) {
             if (fn.busy) continue
             fn.busy = 1
-            if (!ns || fn.ns == ns) fn.apply(el, fn.typed ? [name].concat(args) : args)
+            fn.apply(el, fn.typed ? [name].concat(args) : args)
             if (fns[i] !== fn) { i-- }
             fn.busy = 0
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ var observable = function(el) {
         if (events == '*' && !fn) callbacks = {}
         else {
           onEachEvent(events, function(name, pos) {
-            if (fn || ns) {
+            if (fn) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
                 if (cb == fn) arr.splice(i--, 1)

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ var observable = function(el) {
       value: function(events, fn) {
         if (events == '*' && !fn) callbacks = {}
         else {
-          onEachEvent(events, function(name, pos, ns) {
+          onEachEvent(events, function(name, pos) {
             if (fn || ns) {
               var arr = callbacks[name]
               for (var i = 0, cb; cb = arr && arr[i]; ++i) {
@@ -123,7 +123,7 @@ var observable = function(el) {
           args[i] = arguments[i + 1] // skip first argument
         }
 
-        onEachEvent(events, function(name, pos, ns) {
+        onEachEvent(events, function(name, pos) {
 
           fns = slice.call(callbacks[name] || [], 0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riot-observable",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Simple script to send and receive events",
   "main": "dist/observable.js",
   "jsnext:main": "dist/es6.observable.js",
@@ -21,15 +21,15 @@
     "events"
   ],
   "devDependencies": {
-    "benchmark": "^2.1.0",
-    "coveralls": "^2.11.9",
-    "eslint": "^2.8.0",
+    "benchmark": "^2.1.1",
+    "coveralls": "^2.11.11",
+    "eslint": "^3.1.1",
     "expect.js": "^0.3.1",
-    "karma": "^0.13.22",
-    "karma-coverage": "^0.5.5",
-    "karma-mocha": "^0.2.2",
-    "karma-phantomjs-launcher": "^1.0.0",
-    "mocha": "^2.4.5",
+    "karma": "^1.1.1",
+    "karma-coverage": "^1.1.1",
+    "karma-mocha": "^1.1.1",
+    "karma-phantomjs-launcher": "^1.0.1",
+    "mocha": "^2.5.3",
     "phantomjs-prebuilt": "^2.1.7"
   },
   "author": "Muut, Inc. and other contributors",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -10,7 +10,6 @@ module.exports = function(config) {
       'karma-phantomjs-launcher'
     ],
     files: [
-      '../node_modules/mocha/mocha.js',
       '../node_modules/expect.js/index.js',
       '../dist/observable.js',
       'specs/core.specs.js'

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -67,8 +67,39 @@ describe('Core specs', function() {
 
   })
 
-  it('multiple listeners with special chars', function() {
+  it('single listener with always', function(done) {
 
+    el.on('a', function(arg){
+      expect(arg).to.be(true)
+    })
+
+    el.trigger('a', true)
+
+    el.on('a', function(arg) {
+      expect(arg).to.be(true)
+      done()
+    }, true)
+
+  })
+
+  it('single listener without always', function(done) {
+
+    el.on('b', function(arg){
+      expect(arg).to.be(true)
+    })
+
+    el.trigger('b', true)
+
+    el.on('b', function(arg) {
+      done('This should not run')
+    })
+
+    setTimeout(done, 1000)
+
+  })
+
+  it('multiple listeners with special chars', function() {
+    var counter = 0
     el.on('b/4 c-d d:x', function(e) {
       if (++counter == 3) expect(e).to.be('d:x')
     })
@@ -82,12 +113,22 @@ describe('Core specs', function() {
   })
 
   it('one', function() {
-
+    var counter = 0
     el.one('g', function() {
       expect(++counter).to.be(1)
     })
 
     el.trigger('g').trigger('g')
+
+  })
+
+  it('one with always', function(done) {
+
+    el.trigger('g').trigger('g')
+    el.one('g', function() {
+      expect(++counter).to.be(1)
+      done()
+    }, true)
 
   })
 
@@ -400,4 +441,3 @@ describe('Core specs', function() {
     expect(counter).to.be(2)
   })
 })
-

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -399,21 +399,5 @@ describe('Core specs', function() {
     el.trigger('event')
     expect(counter).to.be(2)
   })
-
-  it('The namespaced events are properly called', function() {
-
-    el
-      .on('hello', function(a) { counter++ })
-      .on('hello.world', function(a) { counter++ })
-
-    el.trigger('hello', 'both')
-    expect(counter).to.be(2)
-    el.trigger('hello.world', 'one')
-    expect(counter).to.be(3)
-    el.off('hello.world')
-    el.trigger('hello', 'just "hello"')
-    expect(counter).to.be(4)
-  })
-
 })
 


### PR DESCRIPTION
Replacement for https://github.com/riot/observable/pull/20

This does not use namespaces.

The purpose of this is to capture events that should be triggered in highly dynamic environments and execute them. This prevents race conditions.

This is helpful in many situations, but a couple I've used it in are:
- my page is setup and waiting for websocket data from the server. Once a connection is made, trigger a connect event. There are times, when the websocket will connect before the page finishes loading. I still want the connect events to execute and ALWAYS execute everytime the connect event happens.
- mounting tags asynchronously from the server and one tag triggers an event that another tag needs to execute. With the persist, I don't have to worry about what order my tags are loaded in.

Basically, this solves any issue where race conditions are an issue with your events.

Example:

```
var app = {};
riot.observable(app);
app.trigger('connect');
app.on('connect', function(){
  // this will still execute even though it is setup AFTER the trigger
}, true); // <- note the persist boolean.
```
### Note: this was originally branched from master, I haven't merged in the dev branch to see what that looks like.
